### PR TITLE
Update DCA from upstream to be level with v23.3.1

### DIFF
--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -48,23 +48,10 @@ jobs:
         run: |
           # has to activate each bash step
           source .venv/bin/activate
-          # use 'poetry' to install schematic dev schematic
-          # If commit is tagged for release or in main branch, install schematic from pypi
-          if [[ $GITHUB_REF_NAME == v*.*.* ]] || [[ $GITHUB_REF_NAME == main ]]; then
-            echo Installing pypi version of schematic
-            git clone --single-branch --branch main https://github.com/Sage-Bionetworks/schematic.git
-            cp schematic_config.yml schematic/config.yml
-            cd schematic
-            pip3 install schematicpy
-          else
-            pip3 install poetry
-            echo Installing develop branch of schematic from github
-            git clone --single-branch --branch develop https://github.com/Sage-Bionetworks/schematic.git
-            cp schematic_config.yml schematic/config.yml
-            cd schematic
-            poetry build
-            pip3 install dist/schematicpy-1.0.0-py3-none-any.whl
-          fi
+          echo Installing pypi version of schematic
+          git clone --single-branch --branch main https://github.com/Sage-Bionetworks/schematic.git
+          cp schematic_config.yml schematic/config.yml
+          pip3 install schematicpy
 
       - name: Set Configurations for Schematic
         shell: bash
@@ -131,4 +118,14 @@ jobs:
             finally=close(configFileConn)
           )
           rsconnect::setAccountInfo(rsConnectUser, rsConnectToken, rsConnectSecret)
-          rsconnect::deployApp(appName = appName)
+          # Get app names. If app exists, configure then deploy. Otherwise
+          # deploy then configure
+          apps <- rsconnect::applications()$name
+          if (appName %in% apps) {
+            rsconnect::configureApp(appName = appName, size = "xxxlarge", logLevel = "verbose")
+            rsconnect::deployApp(appName = appName)
+          } else {
+            rsconnect::deployApp(appName = appName)
+            rsconnect::configureApp(appName = appName, size = "xxxlarge", logLevel = "verbose")
+          }
+          

--- a/functions/validationResult.R
+++ b/functions/validationResult.R
@@ -121,7 +121,7 @@ validationResult <- function(anno.res, template, manifest = NULL, dashboard = FA
       # similar warnings in the same column should be concatenated from backend, like "['value1', 'value2', ...]"
       # extract the single quoted values from the warning string
       if (!is.null(warn[[4]])) {
-        warn_values <- gsub("^[^']*'|'\\],?$", "", strsplit(warn[[4]], "'(?=,)", perl = TRUE)[[1]])
+        warn_values <- gsub("^[^']*'|'\\],?$", "", strsplit(as.character(warn[[4]]), "'(?=,)", perl = TRUE)[[1]])
       } else {
         # if matchExactOne (set) warning exist, highlight entire column
         warn_values <- "ht_entire_column"


### PR DESCRIPTION
This PR updates HTANs DCA to fix #68 

* Develop no poetry (#477)

* Set instance size to xxxlarge and log level to verbose during app deploy.

* Only install schematic from pip, never use develop branch.

* configureApp() will fail if the app does not exist yet. Put after deployApp() in case of first deployment.

* try setting upload to FALSE and then configure it. The configApp() fails after deployApp()

* if app exists, configure then deploy. Otherwise, deploy then configure.

* change appName to testingXXX so it creates a new app instance and tests if the rsconnect configuration logic works.

* Logic worked, go back to testing1 name

* coerce warning to character so strsplit() does not fail. (#520)

---------